### PR TITLE
Removed taskList from template and readme

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap-element.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap-element.yml
@@ -12,6 +12,8 @@ body:
     attributes:
       label: Overordnet beskrivelse
       description: En *veldig* overordnet beskrivelse
+      value: |
+        ## Overordnet beskrivelse        
     validations:
       required: true
   - type: textarea
@@ -19,6 +21,8 @@ body:
     attributes:
       label: Forventet resultat
       description: Overordnede resultater eller effekter
+      value: |
+        ## Forventet resultat
     validations:
       required: true
   - type: textarea
@@ -26,6 +30,8 @@ body:
     attributes:
       label: Hvordan skal det fungere?
       description: Overordnet funksjonell beskrivelse av hvordan det skal fungere
+      value: |
+        ## Hvordan skal det fungere?        
     validations:
       required: true
   - type: textarea
@@ -34,6 +40,7 @@ body:
       label: Gjennomføring
       description: Task lists for Avhengigheter og Oppgaver. Disse kan slettes og legges til på et senere tidspunkt.
       value: |
+        ## Gjennomføring
         ### Avhengigheter
         - [ ] Draft avhengighet
         

--- a/.github/ISSUE_TEMPLATE/roadmap-element.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap-element.yml
@@ -11,9 +11,7 @@ body:
     id: description
     attributes:
       label: Overordnet beskrivelse
-      description: En *veldig* overordnet beskrivelse
-      value: |
-        ## Overordnet beskrivelse        
+      description: En *veldig* overordnet beskrivelse       
     validations:
       required: true
   - type: textarea
@@ -21,17 +19,13 @@ body:
     attributes:
       label: Forventet resultat
       description: Overordnede resultater eller effekter
-      value: |
-        ## Forventet resultat
     validations:
       required: true
   - type: textarea
     id: how
     attributes:
       label: Hvordan skal det fungere?
-      description: Overordnet funksjonell beskrivelse av hvordan det skal fungere
-      value: |
-        ## Hvordan skal det fungere?        
+      description: Overordnet funksjonell beskrivelse av hvordan det skal fungere   
     validations:
       required: true
   - type: textarea
@@ -40,7 +34,6 @@ body:
       label: Gjennomføring
       description: Task lists for Avhengigheter og Oppgaver. Disse kan slettes og legges til på et senere tidspunkt.
       value: |
-        ## Gjennomføring
         ### Avhengigheter
         - [ ] Draft avhengighet
         

--- a/.github/ISSUE_TEMPLATE/roadmap-element.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap-element.yml
@@ -1,6 +1,6 @@
 name: Roadmap 🛣️
 description: Opprett et nytt roadmap element
-projects: digdir/8
+projects: [digdir/8]
 body:
   - type: markdown
     attributes:
@@ -34,14 +34,11 @@ body:
       label: Gjennomføring
       description: Task lists for Avhengigheter og Oppgaver. Disse kan slettes og legges til på et senere tidspunkt.
       value: |
-        ```[tasklist]
         ### Avhengigheter
         - [ ] Draft avhengighet
-        ```
-        ```[tasklist]
+        
         ### Oppgaver
         - [ ] Draft epos
-        ```
     validations:
       required: false
   - type: markdown

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Elementene i roadmap skal beskrives kort og presist, på et helt overordnet niv�
 - Forventet resultat
 - Hvordan skal det fungere?
 - Gjennomføring
-  - Avhengigheter (en tasklist med avhengigheter til andre produkter)
-  - Tasks (en eller flere tasklists med epos som skal leveres)
+  - Avhengigheter (en liste med avhengigheter til andre produkter)
+  - Oppgaver (en liste med epos som skal leveres)
 
 Tittel skal være kort og konsis, men gi mening også på tvers av produkter i ulike visninger.  
 Avhengigheter og Tasks **skal** legges inn som [tasklists](https://github.com/digdir/roadmap#tasklists).
@@ -70,25 +70,16 @@ Hver produkt har tre ulike layouts for visning av leveransene. Du kan [selv velg
 
 Uavhengig av hvilken layout som benyttes, så kan du alltid se på den enkelte leveranse ved å trykke på den.
 
-### Tasklists
+### Oppgaver
 
 For at veikart skal kunne gi de ønskede effektene så **skal** koblinger mot epos i underliggende backlogs legges inn.
 
-Hvert element i roadmap skal inneholde en eller flere [tasklist](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-tasklists) som lenker ned mot ett eller flere epos i produktbacklog.  
+Hvert element i roadmap skal inneholde en liste som lenker ned mot ett eller flere epos i produktbacklog.  
 Når alle lenkede epos er lukket så kan roadmap-elementet også lukkes.
-
-MERK: Det er viktig at tasklist med avhengigheter har tittel `Avhengigheter`, da dette benyttes ifbm. rapportering. Se også [nivå](https://github.com/digdir/roadmap#niv%C3%A5) for mer info.
 
 Se [eksempel](https://github.com/orgs/digdir/projects/8/views/2?pane=issue&itemId=24019705) fra roadmap for Altinn Studio:
 
 ![image](https://github.com/digdir/roadmap/assets/6088624/a1e61139-5d6f-4056-8c6f-be13956677a9)
-
-### Tracks
-Bruk av [tasklist](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-tasklists) gjør at man i tabell-layout for et produkt kan følge med på status på tvers av underliggende epos med en ["Tracks"-kolonne](https://docs.github.com/en/issues/planning-and-tracking-with-projects/understanding-fields/about-tracks-and-tracked-by-fields#enabling-the-tracks-field).
-
-Se [eksempel](https://github.com/orgs/digdir/projects/8/views/5?layout=table) fra roadmap for Autorisasjon:
-
-![Image](https://user-images.githubusercontent.com/6088624/245457571-d7aa1d58-5d28-48a6-ba31-864435e055f9.png)
 
 ### Labels
 Hvert produkt har sin egen label, og hvert element i roadmap skal ha kun ha en produktlabel.  


### PR DESCRIPTION
The tasklist feature is removed from GitHub and is no longer in use. This PR removes the use of tasklist from the roadmap issue template and updates the readme.md accordinglyl.